### PR TITLE
Add value tuple support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Both methods allow you to specify any combination of the following `TypeNameForm
 * **`NoNullableQuestionMark`**:
   Nullable types should not be formatted using C# question mark syntax. (For example, `Nullable<int>` instead of `int?`.)
 
+* **`NoTuple`**:
+  Value tuple types should not be formatted using C# tuple syntax. (For example, `ValueTuple<bool, int>` instead of `(bool, int)`.)
+
 
 ## But it doesn't format \<some type\> correctly!
 

--- a/src/TypeNameFormatter.Tests/Tests.cs
+++ b/src/TypeNameFormatter.Tests/Tests.cs
@@ -342,5 +342,17 @@ namespace TypeNameFormatter
         {
             Assert.Equal(expectedFormattedName, type.GetFormattedName(options));
         }
+
+        [Theory]
+        [InlineData("(bool, int)", typeof(System.ValueTuple<bool, int>), TypeNameFormatOptions.Default)]
+        [InlineData("ValueTuple<bool, int>", typeof(System.ValueTuple<bool, int>), TypeNameFormatOptions.NoTuple)]
+        [InlineData("(A, N.S?)", typeof(System.ValueTuple<global::A, global::N.S?>), TypeNameFormatOptions.Namespaces)]
+        [InlineData("(A, Nullable<S>)", typeof(System.ValueTuple<global::A, global::N.S?>), TypeNameFormatOptions.NoNullableQuestionMark)]
+        [InlineData("(bool, int)?", typeof((bool, int)?), TypeNameFormatOptions.Default)]
+        [InlineData("A<(bool, int)?[]>", typeof(global::A<(bool, int)?[]>), TypeNameFormatOptions.Default)]
+        public void Value_tuple(string expectedFormattedName, Type type, TypeNameFormatOptions options)
+        {
+            Assert.Equal(expectedFormattedName, type.GetFormattedName(options));
+        }
     }
 }

--- a/src/TypeNameFormatter/TypeName.cs
+++ b/src/TypeNameFormatter/TypeName.cs
@@ -127,15 +127,33 @@ namespace TypeNameFormatter
 
             if (type.IsGenericParameter == false)
             {
+                var isGenericType = IsGenericType(type);
+
                 if (type.IsNested)
                 {
                     stringBuilder.AppendFormattedName(type.DeclaringType, options, genericTypeArgs);
                     stringBuilder.Append('.');
                 }
-                else if (IsSet(TypeNameFormatOptions.NoNullableQuestionMark, options) == false && IsGenericType(type) && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                else if (isGenericType && IsSet(TypeNameFormatOptions.NoNullableQuestionMark, options) == false && type.GetGenericTypeDefinition() == typeof(Nullable<>))
                 {
                     stringBuilder.AppendFormattedName(genericTypeArgs[0], options);
                     stringBuilder.Append('?');
+                    return;
+                }
+                else if (isGenericType && IsSet(TypeNameFormatOptions.NoTuple, options) == false && type.Name.StartsWith("ValueTuple`", StringComparison.Ordinal) && type.Namespace == "System")
+                {
+                    stringBuilder.Append('(');
+                    for (int i = 0, n = genericTypeArgs.Length; i < n; ++i)
+                    {
+                        if (i > 0)
+                        {
+                            stringBuilder.Append(", ");
+                        }
+
+                        stringBuilder.AppendFormattedName(genericTypeArgs[i], options);
+                    }
+
+                    stringBuilder.Append(')');
                     return;
                 }
                 else if (IsSet(TypeNameFormatOptions.Namespaces, options))

--- a/src/TypeNameFormatter/TypeNameFormatOptions.cs
+++ b/src/TypeNameFormatter/TypeNameFormatOptions.cs
@@ -56,5 +56,15 @@ namespace TypeNameFormatter
         ///   </example>
         /// </summary>
         NoNullableQuestionMark = 8,
+
+        /// <summary>
+        ///   Specifies that value tuple types should not be transformed to C# tuple syntax.
+        ///   <example>
+        ///   For example, the type <see cref="T:System.ValueTuple`2"/> of <see cref="Boolean"/>, <see cref="Int32"/>
+        ///   is formatted as <c>"(bool, int)"</c> by default. When this flag is specified,
+        ///   it will be formatted as <c>"ValueTuple&lt;bool, int&gt;"</c>.
+        ///   </example>
+        /// </summary>
+        NoTuple = 16,
     }
 }


### PR DESCRIPTION
Its perhaps important to note that just like the C# compiler, the library recognizes any type named ``System.ValueTuple`n`` as a value tuple type. (On older target frameworks, the type is not defined in
mscorlib / System.Runtime yet, while on new ones it is, so instead of only recognizing one specific assembly-qualified type name, it applies some kind of duck typing.)

This resolves #12.