### PR TITLE
Invert definiton of `GenericParameterNames` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ By importing the `TypeNameFormatter` namespace, the following extension methods 
 
 Both methods allow you to specify any combination of the following `TypeNameFormatOptions` flags:
 
-* **`GenericParameterNames`**:  
-  Parameter names of an open generic type should be included. (For example, `IEnumerable<T>` instead of `IEnumerable<>`. Note that this setting does not affect closed generic types; their arguments are always included.)
-
 * **`Namespaces`**:  
   Namespaces should be included. (For example, `System.Action` instead of `Action`.)
 
 * **`NoAnonymousTypes`**:
   Anonymous types should not have their "display class" name transformed to a more legible syntax. (For example, `<>f__AnonymousType5<string, int>` instead of `{string Name, int Count}`.)
+
+* **`NoGenericParameterNames`**:  
+  Parameter names of an open generic type should be omitted. (For example, `IEnumerable<>` instead of `IEnumerable<T>`. Note that this setting does not affect closed generic types; their arguments are always included.)
 
 * **`NoKeywords`**:  
   Primitive types should not be mapped to their corresponding C# language keywords. (For example, `Int32` instead of `int`.)

--- a/src/TypeNameFormatter.Tests/Tests.cs
+++ b/src/TypeNameFormatter.Tests/Tests.cs
@@ -60,9 +60,9 @@ namespace TypeNameFormatter
         [InlineData("A<,>", typeof(global::A<,>))]
         [InlineData("A<,>", typeof(global::N.A<,>))]
         [InlineData("A<,>", typeof(global::N.O.A<,>))]
-        public void Generic_type_Name(string expectedFormattedName, Type type)
+        public void Generic_type_without_parameter_names_Name(string expectedFormattedName, Type type)
         {
-            Assert.Equal(expectedFormattedName, type.GetFormattedName());
+            Assert.Equal(expectedFormattedName, type.GetFormattedName(TypeNameFormatOptions.NoGenericParameterNames));
         }
 
         [Theory]
@@ -72,9 +72,9 @@ namespace TypeNameFormatter
         [InlineData("A<T, U>", typeof(global::A<,>))]
         [InlineData("A<T, U>", typeof(global::N.A<,>))]
         [InlineData("A<T, U>", typeof(global::N.O.A<,>))]
-        public void Generic_type_with_parameter_names_Name(string expectedFormattedName, Type type)
+        public void Generic_type_Name(string expectedFormattedName, Type type)
         {
-            Assert.Equal(expectedFormattedName, type.GetFormattedName(TypeNameFormatOptions.GenericParameterNames));
+            Assert.Equal(expectedFormattedName, type.GetFormattedName(TypeNameFormatOptions.Default));
         }
 
         [Theory]
@@ -86,7 +86,7 @@ namespace TypeNameFormatter
         [InlineData("N.O.A<T, U>", typeof(global::N.O.A<,>))]
         public void Generic_type_with_parameter_names_FullName(string expectedFormattedName, Type type)
         {
-            Assert.Equal(expectedFormattedName, type.GetFormattedName(TypeNameFormatOptions.Namespaces | TypeNameFormatOptions.GenericParameterNames));
+            Assert.Equal(expectedFormattedName, type.GetFormattedName(TypeNameFormatOptions.Namespaces));
         }
 
         [Theory]
@@ -165,19 +165,19 @@ namespace TypeNameFormatter
         [InlineData("A<T, U>.B<V, W>.C<X, Y>", typeof(global::A<,>.B<,>.C<,>))]
         public void Nested_generic_type(string expectedName, Type type)
         {
-            Assert.Equal(expectedName, type.GetFormattedName(TypeNameFormatOptions.GenericParameterNames));
+            Assert.Equal(expectedName, type.GetFormattedName(TypeNameFormatOptions.Default));
         }
 
         [Fact]
         public void Nested_generic_type_instantiation_FullName()
         {
-            Assert.Equal("A<A>.B<N.A, N.O.A>.C<A>", typeof(global::A<global::A>.B<global::N.A, global::N.O.A>.C<global::A>).GetFormattedName(TypeNameFormatOptions.Namespaces | TypeNameFormatOptions.GenericParameterNames));
+            Assert.Equal("A<A>.B<N.A, N.O.A>.C<A>", typeof(global::A<global::A>.B<global::N.A, global::N.O.A>.C<global::A>).GetFormattedName(TypeNameFormatOptions.Namespaces));
         }
 
         [Fact]
         public void Nested_recursive_generic_type_instantiation_FullName()
         {
-            Assert.Equal("A<A>.B<N.A<N.O.A<A>>, N.O.A>.C<A>", typeof(global::A<global::A>.B<global::N.A<global::N.O.A<global::A>>, global::N.O.A>.C<global::A>).GetFormattedName(TypeNameFormatOptions.Namespaces | TypeNameFormatOptions.GenericParameterNames));
+            Assert.Equal("A<A>.B<N.A<N.O.A<A>>, N.O.A>.C<A>", typeof(global::A<global::A>.B<global::N.A<global::N.O.A<global::A>>, global::N.O.A>.C<global::A>).GetFormattedName(TypeNameFormatOptions.Namespaces));
         }
 
         [Theory]
@@ -329,7 +329,8 @@ namespace TypeNameFormatter
         }
 
         [Theory]
-        [InlineData("Nullable<>", typeof(global::System.Nullable<>), TypeNameFormatOptions.Default)]
+        [InlineData("Nullable<T>", typeof(global::System.Nullable<>), TypeNameFormatOptions.Default)]
+        [InlineData("Nullable<>", typeof(global::System.Nullable<>), TypeNameFormatOptions.NoGenericParameterNames)]
         [InlineData("int?", typeof(int?), TypeNameFormatOptions.Default)]
         [InlineData("Int32?", typeof(int?), TypeNameFormatOptions.NoKeywords)]
         [InlineData("Nullable<int>", typeof(int?), TypeNameFormatOptions.NoNullableQuestionMark)]
@@ -346,8 +347,8 @@ namespace TypeNameFormatter
         }
 
         [Theory]
-        [InlineData("ValueTuple<,>", typeof(global::System.ValueTuple<,>), TypeNameFormatOptions.Default)]
-        [InlineData("ValueTuple<T1, T2>", typeof(global::System.ValueTuple<,>), TypeNameFormatOptions.GenericParameterNames)]
+        [InlineData("ValueTuple<T1, T2>", typeof(global::System.ValueTuple<,>), TypeNameFormatOptions.Default)]
+        [InlineData("ValueTuple<,>", typeof(global::System.ValueTuple<,>), TypeNameFormatOptions.NoGenericParameterNames)]
         [InlineData("(bool, int)", typeof(System.ValueTuple<bool, int>), TypeNameFormatOptions.Default)]
         [InlineData("ValueTuple<bool, int>", typeof(System.ValueTuple<bool, int>), TypeNameFormatOptions.NoTuple)]
         [InlineData("(A, N.S?)", typeof(System.ValueTuple<global::A, global::N.S?>), TypeNameFormatOptions.Namespaces)]
@@ -373,13 +374,12 @@ namespace TypeNameFormatter
                 yield return new object[] { "T[]", typeof(global::A<>).GetField(nameof(global::A<object>.Array)).FieldType, TypeNameFormatOptions.Default };
                 yield return new object[] { "(T, T)", typeof(global::A<>).GetField(nameof(global::A<object>.Tuple)).FieldType, TypeNameFormatOptions.Default };
 
-                yield return new object[] { "A<>", typeof(global::A<>).GetField(nameof(global::A<object>.Self)).FieldType, TypeNameFormatOptions.Default };
+                yield return new object[] { "A<>", typeof(global::A<>).GetField(nameof(global::A<object>.Self)).FieldType, TypeNameFormatOptions.NoGenericParameterNames };
                 // ^ NOTE: Ideally, this would also be rendered as `A<T>` but due to a limitation in Reflection,
                 //   this doesn't appear to be possible. See explanation over at the definition of `A<>.Self`.
 
-                yield return new object[] { "A<T>", typeof(global::A<>).GetField(nameof(global::A<object>.Self)).FieldType, TypeNameFormatOptions.GenericParameterNames };
+                yield return new object[] { "A<T>", typeof(global::A<>).GetField(nameof(global::A<object>.Self)).FieldType, TypeNameFormatOptions.Default };
                 yield return new object[] { "A<T>.B<T>", typeof(global::A<>).GetField(nameof(global::A<object>.OtherGeneric)).FieldType, TypeNameFormatOptions.Default };
-                yield return new object[] { "A<T>.B<T>", typeof(global::A<>).GetField(nameof(global::A<object>.OtherGeneric)).FieldType, TypeNameFormatOptions.GenericParameterNames };
             }
         }
 

--- a/src/TypeNameFormatter/TypeName.cs
+++ b/src/TypeNameFormatter/TypeName.cs
@@ -237,7 +237,7 @@ namespace TypeNameFormatter
                 {
                     stringBuilder.Append('<');
 
-                    if (isConstructedGenericType || IsSet(TypeNameFormatOptions.GenericParameterNames, options))
+                    if (isConstructedGenericType || IsSet(TypeNameFormatOptions.NoGenericParameterNames, options) == false)
                     {
                         var genericTypeArgs = GetGenericTypeArguments(typeWithGenericTypeArgs);
 

--- a/src/TypeNameFormatter/TypeNameFormatOptions.cs
+++ b/src/TypeNameFormatter/TypeNameFormatOptions.cs
@@ -22,13 +22,13 @@ namespace TypeNameFormatter
         Default = 0,
 
         /// <summary>
-        ///   Specifies that a open generic type's parameter names should be included.
+        ///   Specifies that an open generic type's parameter names should be omitted.
         ///   <example>
-        ///     For example, the open generic type <see cref="IEquatable{T}"/> is formatted as <c>"IEquatable&lt;&gt;"</c> by default.
-        ///     When this flag is specified, it will be formatted as <c>"IEquatable&lt;T&gt;"</c>.
+        ///     For example, the open generic type <see cref="IEquatable{T}"/> is formatted as <c>"IEquatable&lt;T&gt;"</c> by default.
+        ///     When this flag is specified, it will be formatted as <c>"IEquatable&lt;&gt;"</c>.
         ///   </example>
         /// </summary>
-        GenericParameterNames = 1,
+        NoGenericParameterNames = 1,
 
         /// <summary>
         ///   Specifies that a type's namespace should be included.


### PR DESCRIPTION
This turns the flag into `NoGenericParameterNames`. That is, generic parameter names are now included by default and one has to explicitly opt out to have them omitted.

The reason for this is to make it less likely for people to stumble on output that will seem like a bug in the library, but is really caused by a limitation of Reflection. There are some cases where we cannot determine whether we are dealing with a generic type parameter (which depending on the flags you might want to omit), or with a type argument (which should never be omitted). Reflection will incorrectly tend towards the former:

```csharp
class Type<T>
{
    Type<T> Field;
}
```

Formatting the type's name can be `Type<T>` or `Type<>` depending on the options, but formatting the field's type should always yield `Type<T>` because it's actually a "semi"-constructed generic type instantiated over its own type argument. But we cannot detect this.

Closes #20.