### PR TITLE
Prevent breaking downstream build using MSBuild

### DIFF
--- a/src/TypeNameFormatter/TypeNameFormatter.Sources.targets
+++ b/src/TypeNameFormatter/TypeNameFormatter.Sources.targets
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<Project InitialTargets="_TypeNameFormatterCopy" TreatAsLocalProperty="IsCompatibleWithProject;SourceFolder">
+<Project TreatAsLocalProperty="IsCompatibleWithProject;SourceFolder">
 
   <!-- Public properties -->
   <PropertyGroup>


### PR DESCRIPTION
This is supposed to fix the problem mentioned in https://github.com/stakx/TypeNameFormatter/issues/22#issuecomment-395461288.

Using `<Project InitialTargets>` in the `.targets` file breaks the build of downstream projects when using MSBuild. They end up seeing `TypeNameFormatter.cs` as an assembly that they must reference, which in turn triggers a "CS0006: Metadata file could not be found" error.

Since things work just as well without `InitialTargets`, let's remove it and cross our fingers.