### PR TITLE
Exclude class from code coverage for consuming projects

### DIFF
--- a/src/TypeNameFormatter/TypeNameFormatter.cs
+++ b/src/TypeNameFormatter/TypeNameFormatter.cs
@@ -9,6 +9,7 @@ namespace TypeNameFormatter
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using System.Text;
 
@@ -19,6 +20,7 @@ namespace TypeNameFormatter
     /// </summary>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [ExcludeFromCodeCoverage]
 #if TYPENAMEFORMATTER_INTERNAL
     internal
 #else


### PR DESCRIPTION
Since the unit tests for this class exist outside of the consumer's code.

Fixes #33