### PR TITLE
Exclude class from code coverage for consuming projects

### DIFF
--- a/src/TypeNameFormatter/TypeNameFormatter.cs
+++ b/src/TypeNameFormatter/TypeNameFormatter.cs
@@ -17,7 +17,8 @@ namespace TypeNameFormatter
     ///   <see cref="AppendFormattedName(StringBuilder, Type, TypeNameFormatOptions)"/> and
     ///   <see cref="GetFormattedName(Type, TypeNameFormatOptions)"/>.
     /// </summary>
-    [DebuggerStepThrough]
+    [GeneratedCode("TypeNameFormatter", "1.0.0")]
+    [DebuggerNonUserCode]
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if TYPENAMEFORMATTER_INTERNAL
     internal

--- a/src/TypeNameFormatter/TypeNameFormatter.cs
+++ b/src/TypeNameFormatter/TypeNameFormatter.cs
@@ -6,6 +6,7 @@
 namespace TypeNameFormatter
 {
     using System;
+    using System.CodeDom.Compiler;
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;


### PR DESCRIPTION
Since the unit tests for this class exist outside of the consumer's code.

Changing to the `DebuggerNonUserCode` causes the VS code coverage to ignore it. Adding the `GeneratedCode` one causes style and metrics to also exclude it.

Fixes stakx#33