### PR TITLE
Fix a few broken things with current AppVeyor CI config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     secure: gNgpNPwYjgBSs4Kn8F4CAUeF1YhdK00L6W2S7NTh5cYVjgNwLUU2GPUZwU4dhq65
 
 before_build:
-- msbuild /r ./src/TypeNameFormatter.sln
+- msbuild /t:Restore ./src/TypeNameFormatter.sln
 - choco install codecov
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,6 @@ before_build:
 - msbuild /r ./src/TypeNameFormatter.sln
 - choco install codecov
 
-after_test:
-  - "%USERPROFILE%\\.nuget\\packages\\opencover\\4.7.922\\tools\\OpenCover.Console.exe -register:user -target:\"%USERPROFILE%\\.nuget\\packages\\xunit.runner.console\\2.4.1\\tools\\net472\\xunit.console.x86.exe\" -targetargs:\".\\src\\TypeNameFormatter.Tests\\bin\\Debug\\net47\\TypeNameFormatter.Tests.dll -noshadow\" -filter:\"+[TypeNameFormatter]* -[TypeNameFormatter.Tests]*\" -output:\".\\coverage.xml\""
-  - "codecov -f \"coverage.xml\""
+test_script:
+- '%USERPROFILE%\.nuget\packages\opencover\4.7.922\tools\OpenCover.Console.exe -register:user -target:"%USERPROFILE%\.nuget\packages\xunit.runner.console\2.4.1\tools\net472\xunit.console.x86.exe" -targetargs:".\src\TypeNameFormatter.Tests\bin\Debug\net47\TypeNameFormatter.Tests.dll -noshadow -appveyor" -filter:"+[TypeNameFormatter]* -[TypeNameFormatter.Tests]*" -output:".\coverage.xml" -returntargetcode'
+- codecov -f "coverage.xml"


### PR DESCRIPTION
* Badge in `README.md` currently misreports the actual test count. Tests are run three times, and are then reported three-fold. Write a custom `test_script` to prevent AppVeyor from running tests using `dotnet test`, and combine test run with code coverage profiling so a separate third run for the latter is avoided.

* OpenCover will not report error-level correctly when test run fails. Add `-returntargetcode` option for that.

* Simplify YAML a little.