### PR TITLE
Disable nullable context in the file

### DIFF
--- a/src/TypeNameFormatter/TypeNameFormatter.cs
+++ b/src/TypeNameFormatter/TypeNameFormatter.cs
@@ -2,6 +2,7 @@
 // License available at https://github.com/stakx/TypeNameFormatter/blob/master/LICENSE.md.
 
 // ReSharper disable All
+#nullable disable
 
 namespace TypeNameFormatter
 {


### PR DESCRIPTION
Workaround for #42 by just disabling nullable context entirely for the entire file.

Potential improvement would be to actually properly annotate with nullable and fix whatever nullable errors are raised after enabling it.