### PR TITLE
Enable code analysis and fix warnings

### DIFF
--- a/src/TypeNameFormatter/TypeNameFormatter.Nullable.cs
+++ b/src/TypeNameFormatter/TypeNameFormatter.Nullable.cs
@@ -357,6 +357,7 @@ namespace TypeNameFormatter
         /// <summary>
         ///   The default type name formatting options.
         /// </summary>
+        [SuppressMessage("Design", "CA1008:In enum TypeNameFormatOptions, change the name of Default to 'None'")]
         Default = 0,
 
         /// <summary>
@@ -408,7 +409,7 @@ namespace TypeNameFormatter
         /// <summary>
         ///   Specifies that value tuple types should not be transformed to C# tuple syntax.
         ///   <example>
-        ///   For example, the type <see cref="T:System.ValueTuple`2"/> of <see cref="Boolean"/>, <see cref="Int32"/>
+        ///   For example, the type <c>ValueTuple&lt;bool, int&gt;</c>
         ///   is formatted as <c>"(bool, int)"</c> by default. When this flag is specified,
         ///   it will be formatted as <c>"ValueTuple&lt;bool, int&gt;"</c>.
         ///   </example>

--- a/src/TypeNameFormatter/TypeNameFormatter.Nullable.cs
+++ b/src/TypeNameFormatter/TypeNameFormatter.Nullable.cs
@@ -2,6 +2,7 @@
 // License available at https://github.com/stakx/TypeNameFormatter/blob/main/LICENSE.md.
 
 // ReSharper disable All
+#pragma warning disable
 
 #nullable enable
 
@@ -357,7 +358,6 @@ namespace TypeNameFormatter
         /// <summary>
         ///   The default type name formatting options.
         /// </summary>
-        [SuppressMessage("Design", "CA1008:In enum TypeNameFormatOptions, change the name of Default to 'None'")]
         Default = 0,
 
         /// <summary>

--- a/src/TypeNameFormatter/TypeNameFormatter.cs
+++ b/src/TypeNameFormatter/TypeNameFormatter.cs
@@ -2,6 +2,7 @@
 // License available at https://github.com/stakx/TypeNameFormatter/blob/main/LICENSE.md.
 
 // ReSharper disable All
+#pragma warning disable
 
 namespace TypeNameFormatter
 {
@@ -406,7 +407,7 @@ namespace TypeNameFormatter
         /// <summary>
         ///   Specifies that value tuple types should not be transformed to C# tuple syntax.
         ///   <example>
-        ///   For example, the type <see cref="T:System.ValueTuple`2"/> of <see cref="Boolean"/>, <see cref="Int32"/>
+        ///   For example, the type <c>ValueTuple&lt;bool, int&gt;</c>
         ///   is formatted as <c>"(bool, int)"</c> by default. When this flag is specified,
         ///   it will be formatted as <c>"ValueTuple&lt;bool, int&gt;"</c>.
         ///   </example>

--- a/src/TypeNameFormatter/TypeNameFormatter.csproj
+++ b/src/TypeNameFormatter/TypeNameFormatter.csproj
@@ -5,6 +5,9 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AnalysisMode>All</AnalysisMode>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Since TypeNameFormatter is a source code distribution it's important to produce no warnings so that it can be used in projects with strict compilation options.
